### PR TITLE
fix: hydration fee

### DIFF
--- a/ipfs-cids/.hydra-cid
+++ b/ipfs-cids/.hydra-cid
@@ -1,1 +1,1 @@
-Qmc9NHGCfZmCq1NUyq3JgyEasSKj484zfwJU2qc2T99QuR
+QmZ5D1vd2n2aP6L4AAustB4pSznvGSgtsYrvJgd62tzbfu

--- a/src/mappings/swaps/HydraDx.ts
+++ b/src/mappings/swaps/HydraDx.ts
@@ -119,13 +119,11 @@ export type Fee = {
   amount: string;
 };
 
-export function findHydraDxFeeTyped(
-  events: TypedEventRecord<Codec[]>[],
-): Fee | undefined {
+export function findHydraDxFeeTyped(events: TypedEventRecord<Codec[]>[]): Fee {
   return findHydraDxFee(events as EventRecord[]);
 }
 
-export function findHydraDxFee(events: EventRecord[]): Fee | undefined {
+export function findHydraDxFee(events: EventRecord[]): Fee {
   const lastCurrenciesDepositEvent = findLastEvent(events, (event) =>
     isCurrencyDepositedEvent(eventRecordToSubstrateEvent(event)),
   );
@@ -159,9 +157,9 @@ function isPartOfRouterSwap(events: TypedEventRecord<Codec[]>[]): boolean {
   return false;
 }
 
-function findNativeFee(events: EventRecord[]): Fee | undefined {
+function findNativeFee(events: EventRecord[]): Fee {
   let foundAssetTxFeePaid = extractTransactionPaidFee(events);
-  if (foundAssetTxFeePaid == undefined) return undefined;
+  if (foundAssetTxFeePaid == undefined) foundAssetTxFeePaid = "0";
 
   return {
     tokenId: "native",


### PR DESCRIPTION
That PR changes logic for Hydration fee assign for swap feature.
It is done to handle this error:
```
Failed to index block 5604555: TypeError: Cannot read properties of undefined (reading 'tokenId') at t.handleHydraRouterSwap (webpack://subquery-nova/src/mappings/swaps/HydraDx.ts:59:24) TypeError: Cannot read properties of undefined (reading 'tokenId') at t.handleHydraRouterSwap (webpack://subquery-nova/src/mappings/swaps/HydraDx.ts:59:24)
```
That happens, when we can't find event with fee, for example for that swap - https://hydration.subscan.io/extrinsic/5604555-2?event=5604555-28

Tested by:
<img width="1077" alt="Screenshot 2024-09-24 at 15 37 48" src="https://github.com/user-attachments/assets/a5326ae1-e5f2-4b76-b7b2-583cf6c8be70">
<img width="1331" alt="Screenshot 2024-09-24 at 15 38 21" src="https://github.com/user-attachments/assets/52de4d2a-cd77-40d6-8328-cc2ed03b9ae6">


