### PR TITLE
Fix/slash_handler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,7 @@ services:
     command:
       - -f=/app/${PROJECT_PATH}
       - --disable-historical=true
-      # - --local #remove
-      # - --batch-size=50
+      - --batch-size=1
 
   graphql-engine:
     container_name: "query-${PROJECT_PATH}"

--- a/kusama.yaml
+++ b/kusama.yaml
@@ -21,7 +21,7 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 25967189
+    startBlock: 1
     mapping:
       file: ./dist/index.js
       handlers:

--- a/kusama.yaml
+++ b/kusama.yaml
@@ -21,14 +21,14 @@ network:
 dataSources:
   - name: main
     kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 25967189
     mapping:
       file: ./dist/index.js
       handlers:
-        # - handler: handleHistoryElement
-        #   kind: substrate/CallHandler
-        #   filter:
-        #     isSigned: true
+        - handler: handleHistoryElement
+          kind: substrate/CallHandler
+          filter:
+            isSigned: true
         - handler: handleReward
           kind: substrate/EventHandler
           filter:

--- a/polkadot.yaml
+++ b/polkadot.yaml
@@ -26,10 +26,10 @@ dataSources:
     mapping:
       file: ./dist/index.js
       handlers:
-        # - handler: handleHistoryElement
-        #   kind: substrate/CallHandler
-        #   filter:
-        #     isSigned: true
+        - handler: handleHistoryElement
+          kind: substrate/CallHandler
+          filter:
+            isSigned: true
         - handler: handleReward
           kind: substrate/EventHandler
           filter:

--- a/src/mappings/PoolRewards.ts
+++ b/src/mappings/PoolRewards.ts
@@ -151,12 +151,11 @@ export async function handlePoolUnbondingSlash(
   } = unbondingSlashEvent;
   const poolIdNumber = poolId.toNumber();
   const eraIdNumber = era.toNumber();
-  logger.info("poolId:" + poolIdNumber.toString());
-  const test = await api.query.nominationPools.subPoolsStorage(poolIdNumber);
-  logger.info("poolStorage:" + test.toString());
 
   const unbondingPools = (
-    test as Option<PalletNominationPoolsSubPools>
+    (await api.query.nominationPools.subPoolsStorage(
+      poolIdNumber,
+    )) as Option<PalletNominationPoolsSubPools>
   ).unwrap();
 
   const pool =

--- a/src/mappings/PoolRewards.ts
+++ b/src/mappings/PoolRewards.ts
@@ -141,21 +141,22 @@ export async function handlePoolBondedSlash(
 
 export async function handlePoolUnbondingSlash(
   unbondingSlashEvent: SubstrateEvent<
-    [era: INumber, poolId: INumber, slash: INumber]
+    [poolId: INumber, era: INumber, slash: INumber]
   >,
 ): Promise<void> {
   const {
     event: {
-      data: [era, poolId, slash],
+      data: [poolId, era, slash],
     },
   } = unbondingSlashEvent;
   const poolIdNumber = poolId.toNumber();
   const eraIdNumber = era.toNumber();
+  logger.info("poolId:" + poolIdNumber.toString());
+  const test = await api.query.nominationPools.subPoolsStorage(poolIdNumber);
+  logger.info("poolStorage:" + test.toString());
 
   const unbondingPools = (
-    (await api.query.nominationPools.subPoolsStorage(
-      poolIdNumber,
-    )) as Option<PalletNominationPoolsSubPools>
+    test as Option<PalletNominationPoolsSubPools>
   ).unwrap();
 
   const pool =


### PR DESCRIPTION
That PR returns handlers (in order to keep it on in master) and fix error:
```
2024-11-28T15:36:06.813Z <WorkerService-#2> ERROR Failed to index block 25967189: Error: Option: unwrapping a None value
    at Option.unwrap (/node_modules/@polkadot/types-codec/cjs/base/Option.js:213:19)
    at VM2 Wrapper.apply (/node_modules/vm2/lib/bridge.js:485:11)
    at e.handlePoolUnbondingSlash (webpack://subquery-nova/src/mappings/PoolRewards.ts:50:91)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) Error: Option: unwrapping a None value

```

Tested on:

<img width="1077" alt="Screenshot 2024-11-28 at 19 26 02" src="https://github.com/user-attachments/assets/5c716764-b100-409d-b7fa-b03843067b88">
<img width="1464" alt="Screenshot 2024-11-28 at 19 26 18" src="https://github.com/user-attachments/assets/6ba9cdf3-3f88-4f90-93b3-d67dfaef04aa">

https://kusama.subscan.io/event?page=1&time_dimension=date&module=nominationpools&page_size=25&event_id=unbondingpoolslashed