### PR TITLE
bump subql-node versions to v6.3.5

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-js-image-version: [20]
-        subql-node-image-version: [v5.8.0, v6.1.0, v6.3.2]
+        node-js-image-version: [20, 22]
+        subql-node-image-version: [v5.8.0, v6.1.0, v6.3.5]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install
         run: yarn install
       - name: Codegen


### PR DESCRIPTION
Changes:
* bump subql-node versions to v6.3.5. It fixes [the issue](https://github.com/polkadot-js/api/issues/6206)
* add nodejs 22 (LTS)